### PR TITLE
Use tweet-reparse for tweet parsing; standard formatting; deprecation warning fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "feed": "~0.2.6",
-    "twit": "~1.1.20"
-  }
+    "tweet-reparse": "0.0.1",
+    "twit": "~1.1.20",
+  },
 }

--- a/twitter-rss.js
+++ b/twitter-rss.js
@@ -1,64 +1,64 @@
 var Feed = require('feed'),
-	Twit = require('twit'),
-	twitter;
+  Twit = require('twit'),
+  twitter
 
-module.exports = function(CONSUMER_KEY,CONSUMER_SECRET,ACCESS_TOKEN,ACCESS_TOKEN_SECRET) {
-	var module = {};
-	
-	twitter = new Twit({
-		consumer_key: CONSUMER_KEY,
-		consumer_secret: CONSUMER_SECRET,
-		access_token: ACCESS_TOKEN,
-		access_token_secret: ACCESS_TOKEN_SECRET
-	});
-	
-	module.feed = function(screen_name, callback){
-		twitter.get('statuses/user_timeline', {
-			screen_name: screen_name,
-			include_rts: false,
-			count: 25
-		  }, function(err, tweets) {
-			if(err) {
-			  if(typeof callback === 'function'){
-			  	callback(err);
-			  }
-			}
-			else {
-			  var feed = null;
-			  for(var i=0; i<tweets.length; i++) {
-				var tweet = tweets[i];
-				// init new feed on first tweet
-				if(feed == null) {
-				  feed = new Feed({
-					title:          tweet.user.screen_name + ' Twitter RSS',
-					description:    'A generated feed of the tweets from ' + tweet.user.screen_name,
-					link:           'https://twitter.com/' + tweet.user.screen_name,
-					image:          tweet.user.profile_image_url,
+module.exports = function (CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET) {
+  var module = {}
 
-					author: {
-					  name:       tweet.user.name,
-					  email:      '',
-					  link:       'https://twitter.com/' + tweet.user.screen_name
-					}
-				  });
-				}
+  twitter = new Twit({
+    consumer_key: CONSUMER_KEY,
+    consumer_secret: CONSUMER_SECRET,
+    access_token: ACCESS_TOKEN,
+    access_token_secret: ACCESS_TOKEN_SECRET
+  })
 
-				feed.addItem({
-				  title:          tweet.text,
-				  link:           'https://twitter.com/' + tweet.user.screen_name + '/status/' + tweet.id_str,
-				  content:    parseTweetText(tweet.text),
-				  date:           new Date(tweet.created_at)
-				});
-			  }
-			  if(typeof callback === 'function'){
-			  	callback(null, feed);
-			  }
-			}
-		  });
-	};
-	
-	return module;
-};
+  module.feed = function (screen_name, callback) {
+    twitter.get('statuses/user_timeline', {
+      screen_name: screen_name,
+      include_rts: false,
+      count: 25
+    }, function (err, tweets) {
+      if (err) {
+        if (typeof callback === 'function') {
+          callback(err)
+        }
+      } else {
+        var feed = null
+        for (var i = 0; i < tweets.length; i++) {
+          var tweet = tweets[i]
+
+          // init new feed on first tweet
+          if (feed == null) {
+            feed = new Feed({
+              title: tweet.user.screen_name + ' Twitter RSS',
+              description: 'A generated feed of the tweets from ' + tweet.user.screen_name,
+              link: 'https://twitter.com/' + tweet.user.screen_name,
+              image: tweet.user.profile_image_url,
+
+              author: {
+                name: tweet.user.name,
+                email: '',
+                link: 'https://twitter.com/' + tweet.user.screen_name
+              }
+            })
+          }
+
+          feed.addItem({
+            title: tweet.text,
+            link: 'https://twitter.com/' + tweet.user.screen_name + '/status/' + tweet.id_str,
+            content: tweet.text,
+            date: new Date(tweet.created_at)
+          })
+        }
+        if (typeof callback === 'function') {
+          callback(null, feed)
+        }
+      }
+    })
+  }
+
+  return module
+}
 
 var parseTweetText = function(text) {
   text = text.replace(/[@]+[A-Za-z0-9-_]+/g, function(u) {

--- a/twitter-rss.js
+++ b/twitter-rss.js
@@ -43,7 +43,7 @@ module.exports = function(CONSUMER_KEY,CONSUMER_SECRET,ACCESS_TOKEN,ACCESS_TOKEN
 				  });
 				}
 
-				feed.item({
+				feed.addItem({
 				  title:          tweet.text,
 				  link:           'https://twitter.com/' + tweet.user.screen_name + '/status/' + tweet.id_str,
 				  content:    parseTweetText(tweet.text),

--- a/twitter-rss.js
+++ b/twitter-rss.js
@@ -1,5 +1,6 @@
 var Feed = require('feed'),
   Twit = require('twit'),
+  tweetReparse = require('tweet-reparse'),
   twitter
 
 module.exports = function (CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET) {
@@ -27,6 +28,9 @@ module.exports = function (CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_T
         for (var i = 0; i < tweets.length; i++) {
           var tweet = tweets[i]
 
+          // mark up links, mentions, usernames, etc.
+          var text = tweetReparse(tweet)
+
           // init new feed on first tweet
           if (feed == null) {
             feed = new Feed({
@@ -46,7 +50,7 @@ module.exports = function (CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_T
           feed.addItem({
             title: tweet.text,
             link: 'https://twitter.com/' + tweet.user.screen_name + '/status/' + tweet.id_str,
-            content: tweet.text,
+            content: text,
             date: new Date(tweet.created_at)
           })
         }
@@ -60,13 +64,3 @@ module.exports = function (CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_T
   return module
 }
 
-var parseTweetText = function(text) {
-  text = text.replace(/[@]+[A-Za-z0-9-_]+/g, function(u) {
-    var username = u.replace("@","")
-    return u.link("https://twitter.com/"+username);
-  });
-  text = text.replace(/[A-Za-z]+:\/\/[A-Za-z0-9-_]+\.[A-Za-z0-9-_:%&~\?\/.=]+/g, function(url) {
-    return url.link(url);
-  });
-  return text;
-};


### PR DESCRIPTION
This PR does a few things:
1. Use [tweet-reparse](https://github.com/hitsujiwool/tweet-reparse/) to extract entities and inject HTML, rather than ad-hoc parsing.
2. Fixes the deprecation warning on [feed](https://github.com/jpmonette/feed) (`feed#item` -> `feed#addItem`).
3. Changes the code over to [standard](http://standardjs.com/) formatting. This change is probably the most controversial. The current format seems to be a mixture of spaces and tabs so I figured you might be open to something more consistent.
